### PR TITLE
Add simple professional search

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -5,11 +5,31 @@ document.addEventListener('DOMContentLoaded', function() {
     searchForm.addEventListener('submit', function(e) {
       e.preventDefault();
       const oficio = searchForm.oficio.value;
-      const estado = searchForm.estado.value;
+      const delegacion = searchForm.delegacion.value;
       const ciudad = searchForm.ciudad.value;
       const colonia = searchForm.colonia.value;
-      const query = `oficio=${oficio}&estado=${estado}&ciudad=${ciudad}&colonia=${colonia}`;
-      window.location.href = `profesionales.html?${query}`;
+      const query = `oficio=${oficio}&estado=${delegacion}&ciudad=${ciudad}&colonia=${colonia}`;
+
+      const container = document.getElementById('lista-profesionales');
+      if (container) container.innerHTML = '';
+
+      fetch(`/api/profesionales?${query}`)
+        .then(res => res.json())
+        .then(data => {
+          if (container) {
+            data.forEach(pro => {
+              const card = document.createElement('div');
+              card.classList.add('profesional-card');
+              card.innerHTML = `
+                <h3>${pro.nombre}</h3>
+                <p><strong>Oficio:</strong> ${pro.oficio}</p>
+                <p><strong>Delegación:</strong> ${pro.estado}</p>
+                <p><strong>Contacto:</strong> ${pro.contacto}</p>
+              `;
+              container.appendChild(card);
+            });
+          }
+        });
     });
   }
 });

--- a/views/index.html
+++ b/views/index.html
@@ -26,13 +26,8 @@
     </div>
     <ul class="nav-list" id="nav-list">
       <li><a href="index.html">Inicio</a></li>
-      <li><a href="profesionales.html">Profesionales</a></li>
       <li><a href="contacto.html">Contacto</a></li>
-      <li id="link-registrar"><a href="/views/registrar.html">Registrar</a></li>
-      <li id="link-login"><a href="/views/login.html">Iniciar Sesión</a></li>
-      <li id="link-admin" style="display: none"><a href="/views/admin.html">Admin</a></li>
-      <li id="link-logout" style="display: none"><a>Cerrar Sesión</a></li>  
-      <li id="saludo-usuario" style="display: none"><span></span></li>
+      <li><a href="registrar.html">Registrar</a></li>
     </ul>
   </nav>
 </header>
@@ -52,6 +47,7 @@
         <input type="text" name="colonia" placeholder="Colonia">
         <button type="submit">Buscar</button>
       </form>
+      <div id="lista-profesionales" class="profesionales-container"></div>
     </section>
 
     <section id="servicios">

--- a/views/profesionales.html
+++ b/views/profesionales.html
@@ -16,14 +16,9 @@
         <i class="fas fa-bars"></i>
       </div>
       <ul class="nav-list" id="nav-list">
-            <li><a href="index.html">Inicio</a></li>
-            <li><a href="profesionales.html">Profesionales</a></li>
-            <li><a href="contacto.html">Contacto</a></li>
-            <li id="link-registrar"><a href="registrar.html">Registrar</a></li>
-            <li id="link-login"><a href="login.html">Iniciar Sesión</a></li>
-            <li id="link-admin" style="display: none"><a href="admin.html">Admin</a></li>
-            <li id="link-logout" style="display: none"><a>Cerrar Sesión</a></li>  
-             <li id="saludo-usuario" style="display: none"><span></span></li>
+              <li><a href="index.html">Inicio</a></li>
+              <li><a href="contacto.html">Contacto</a></li>
+              <li><a href="registrar.html">Registrar</a></li>
         </ul>
     </nav>
   </header>

--- a/views/registrar.html
+++ b/views/registrar.html
@@ -16,14 +16,9 @@
         <i class="fas fa-bars"></i>
       </div>
       <ul class="nav-list" id="nav-list">
-            <li><a href="index.html">Inicio</a></li>
-            <li><a href="profesionales.html">Profesionales</a></li>
-            <li><a href="contacto.html">Contacto</a></li>
-            <li id="link-registrar"><a href="registrar.html">Registrar</a></li>
-            <li id="link-login"><a href="login.html">Iniciar Sesión</a></li>
-            <li id="link-admin" style="display: none"><a href="admin.html">Admin</a></li>
-            <li id="link-logout" style="display: none"><a>Cerrar Sesión</a></li>  
-             <li id="saludo-usuario" style="display: none"><span></span></li>
+              <li><a href="index.html">Inicio</a></li>
+              <li><a href="contacto.html">Contacto</a></li>
+              <li><a href="registrar.html">Registrar</a></li>
         </ul>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- remove login links from navigation menus
- add results section to `index.html`
- display professional search results on the home page

## Testing
- `npm install`
- `npm start` *(fails: invalid ELF header for sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_683fc79b510c832c86f8ce9523cd3df0